### PR TITLE
duplicate-check-branches optionを追加

### DIFF
--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -108,7 +108,7 @@ export default class Changelog {
     // Determine the tags range to get the commits for. Custom from/to can be
     // provided via command-line options.
     // Default is "from last tag".
-    return Git.listCommits(from, to);
+    return Git.listCommits(from, to, this.config.duplicateCheckBranches);
   }
 
   private async getCommitters(commits: CommitInfo[]): Promise<GitHubUserResponse[]> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,6 +47,10 @@ export async function run() {
         type: "string",
         desc: "指定したパッケージのみを対象にする",
       },
+      "duplicate-check-branches": {
+        type: "string",
+        desc: "指定したブランチに含まれるコミットと重複するコミットを除外する",
+      }
     })
     .example(
       "lerna-changelog",
@@ -76,6 +80,10 @@ export async function run() {
 
     if (argv["projects"]) {
       config.specifiedProjects = argv["projects"].split(',');
+    }
+
+    if (argv["duplicate-check-branches"]) {
+      config.duplicateCheckBranches = argv["duplicate-check-branches"].split(',');
     }
 
     let result = await new Changelog(config).createMarkdown(options);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -15,6 +15,7 @@ export interface Configuration {
   nextVersionFromMetadata?: boolean;
   ignoreFilePath: string[];
   specifiedProjects: string[];
+  duplicateCheckBranches: string[];
 }
 
 export interface ConfigLoaderOptions {
@@ -33,7 +34,7 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
   let config = fromPackageConfig(rootPath) || fromLernaConfig(rootPath) || {};
 
   // Step 2: fill partial config with defaults
-  let { repo, nextVersion, labels, cacheDir, ignoreCommitters, ignoreFilePath, specifiedProjects } = config;
+  let { repo, nextVersion, labels, cacheDir, ignoreCommitters, ignoreFilePath, specifiedProjects, duplicateCheckBranches } = config;
 
   if (!repo) {
     repo = findRepo(rootPath);
@@ -79,6 +80,10 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
     specifiedProjects = []
   }
 
+  if (!duplicateCheckBranches) {
+    duplicateCheckBranches = []
+  }
+
   return {
     repo,
     nextVersion,
@@ -88,6 +93,7 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
     cacheDir,
     ignoreFilePath,
     specifiedProjects,
+    duplicateCheckBranches,
   };
 }
 


### PR DESCRIPTION
Fixes N/A

`--duplicate-check-branches` を追加しました。

指定したブランチに含まれるコミットと重複するコミットを除外します。
コミットメッセージのサマリが一致するかどうかで重複の判定しています

cherry-pickされたコミットは前のリリースノートに既に記載されているのに、
今回のリリースノートにも記載されてしまうのでそれを防ぐことが目的です。

