### PR TITLE
fix: version更新とregistryの修正

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-registry=https://registry.yarnpkg.com
+registry=https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newn-team/lerna-changelog",
-  "version": "0.8.2",
+  "version": "0.8.2-1",
   "description": "Generate a changelog for a lerna monorepo",
   "keywords": [
     "changelog",


### PR DESCRIPTION
fix https://github.com/newn-team/standfm/issues/7199

deploy時に参照するのが本家のライブラリの方だった。
詳細分かりきってないけど、
- バージョンの衝突でおかしくなっている
- npmrcのregistryがyarnに向いている

のどちらかが原因かもしれないので、一旦これでupdateして試してみたい。